### PR TITLE
Fix queue selection

### DIFF
--- a/cluster_helper/slurm.py
+++ b/cluster_helper/slurm.py
@@ -63,7 +63,7 @@ def get_slurm_attributes(queue, resources):
     slurm_atrs = {}
     if resources:
         for parm in resources.split(";"):
-            atr = parm.strip().split('=')
+            atr = [ a.strip() for a in  parm.split('=') ]
             slurm_atrs[atr[0]] = atr[1]
     if "account" not in slurm_atrs:
         slurm_atrs["account"] = get_account_for_queue(queue)


### PR DESCRIPTION
This handles empty sets and also the specific case on our cluster wherein every user has access to a certain queue which results in the set `set(['all'])` which does not intersect with the account names.
