### PR TITLE
allow virtual_free instead of mem_free

### DIFF
--- a/cluster_helper/cluster.py
+++ b/cluster_helper/cluster.py
@@ -327,7 +327,7 @@ def _prep_sge_resource(resource):
     """
     resource = resource.strip()
     k, v = resource.split("=")
-    if k in set(["ar","m","M"]):
+    if k in set(["ar", "m", "M"]):
         return "#$ -%s %s" % (k, v)
     else:
         return "#$ -l %s" % resource

--- a/cluster_helper/cluster.py
+++ b/cluster_helper/cluster.py
@@ -270,6 +270,8 @@ echo \($SGE_TASK_ID - 1\) \* 0.5 | bc | xargs sleep
         if self.mem:
             if self.memtype == "rss":
                 self.context["mem"] = "#$ -l rss=%sM" % int(float(self.mem) * 1024 / self.cores * self.numengines)
+            elif self.memtype == "virtual_free":
+                self.context["mem"] = "#$ -l virtual_free=%sM" % int(float(self.mem) * 1024 * self.numengines)
             else:
                 self.context["mem"] = "#$ -l mem_free=%sM" % int(float(self.mem) * 1024 * self.numengines)
         else:
@@ -325,7 +327,7 @@ def _prep_sge_resource(resource):
     """
     resource = resource.strip()
     k, v = resource.split("=")
-    if k in set(["ar"]):
+    if k in set(["ar","m","M"]):
         return "#$ -%s %s" % (k, v)
     else:
         return "#$ -l %s" % resource


### PR DESCRIPTION
Some SGE clusters use virtual_free to reserve memory. As well, added a way to allow  getting -m and -M as simple parameters in SGE, and get the email with the exists status