### PR TITLE
fix to allow clean build on python3.4

### DIFF
--- a/cluster_helper/cluster.py
+++ b/cluster_helper/cluster.py
@@ -1014,7 +1014,7 @@ def _create_base_ipython_dirs():
     utils.safe_makedir(os.path.join(locate_profile(), "db"))
 
 def _shutdown(client):
-    print "Sending a shutdown signal to the controller and engines."
+    print ("Sending a shutdown signal to the controller and engines.")
     client.close()
 
 def _get_direct_view(client, retries):

--- a/cluster_helper/lsf.py
+++ b/cluster_helper/lsf.py
@@ -139,5 +139,5 @@ def per_core_reservation():
     return False
 
 if __name__ == "__main__":
-    print get_lsf_units()
-    print per_core_reservation()
+    print (get_lsf_units())
+    print (per_core_reservation())


### PR DESCRIPTION
these changes allow for clean install on python3.4, and still works on python2.7 as well.