### PR TITLE
Do not pin ipython so hard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyzmq>=2.1.11
-ipython==4.0.0
+ipython>=4.0.0
 ipyparallel>=4.0.0
 netifaces>=0.10.3


### PR DESCRIPTION
GEMINI made me downgrade my 4.2.x ipython install because of that pinning 👎 