### PR TITLE
replace basestring with six.string_type for python 2/3 compatibility

### DIFF
--- a/cluster_helper/cluster.py
+++ b/cluster_helper/cluster.py
@@ -19,6 +19,7 @@ import time
 import re
 from distutils.version import LooseVersion
 import sys
+import six
 
 from ipyparallel import Client
 from ipyparallel.apps import launcher
@@ -780,7 +781,7 @@ def _scheduler_resources(scheduler, params, queue):
     specials = {}
     if not orig_resources:
         orig_resources = []
-    if isinstance(orig_resources, basestring):
+    if isinstance(orig_resources, six.string_types):
         orig_resources = orig_resources.split(";")
     resources = []
     for r in orig_resources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyzmq>=2.1.11
 ipython>=4.0.0,<5.0.0
 ipyparallel>=4.0.0
 netifaces>=0.10.3
+six>=1.10.0


### PR DESCRIPTION
Thanks again, @peteut & @roryk. This fixes #39 for me.

Let me know if I didn't following any github/python etiquette.