### PR TITLE
Python 3 support for Slurm helper

### DIFF
--- a/cluster_helper/cluster.py
+++ b/cluster_helper/cluster.py
@@ -1187,8 +1187,9 @@ def _slurm_is_old():
     return LooseVersion(_slurm_version()) < LooseVersion("2.6")
 
 def _slurm_version():
-    version_line = subprocess.Popen("sinfo -V", shell=True,
-                                    stdout=subprocess.PIPE).communicate()[0]
+    version_line = subprocess.check_output("sinfo -V", shell=True)
+    if six.PY3:
+        version_line = version_line.decode('ascii', 'ignore')
     parts = version_line.split()
     if len(parts) > 0:
         return version_line.split()[1]


### PR DESCRIPTION
Added python 3 support for Slurm. SGE works fine with python 3 already.

By the way, what do you think about dropping the ipyparallel <5.0 requirement in conda? This will allow to add python 3.6 support. I can't see any breaking changes introduced: https://ipyparallel.readthedocs.io/en/latest/changelog.html#id3,
and it works fine for me (I'm using and altered conda package version https://github.com/vladsaveliev/NGS_Utils/blob/master/conda/ipython-cluster-helper/meta.yaml). However I agree that this might be dangerous and probably not a best idea at all. Just something to consider.